### PR TITLE
Fix for issue #43

### DIFF
--- a/action/edit.php
+++ b/action/edit.php
@@ -149,6 +149,12 @@ class action_plugin_blogtng_edit extends DokuWiki_Action_Plugin{
                 $this->entryhelper->entry['blog'] = $blog;
                 $this->entryhelper->entry['commentstatus'] = $this->tools->getParam('post/commentstatus');
 
+                if (empty($this->entryhelper->entry['page'])) {
+
+                    $this->entryhelper->entry['page'] = $ID;
+
+                }
+
                 // allow to override created date
                 if($this->tools->getParam('post/date') && $this->getConf('editform_set_date')) {
                     foreach(array('hh', 'mm', 'MM', 'DD') as $key) {


### PR DESCRIPTION
Hi people!

I think I figured out issue #43. The page-name isn't set, when a blog page is saved. That way, the new page is saved into the SQLlite and deleted immediately, because no page is given.

I simply set the page name in the "edit" action.

But perhaps that was missing wittingly, so please check it out.

Kind regards
Dennis
