### PR TITLE
Blog optional on blog list syntax

### DIFF
--- a/helper/entry.php
+++ b/helper/entry.php
@@ -653,12 +653,27 @@ class helper_plugin_blogtng_entry extends DokuWiki_Plugin {
 
     function get_posts($conf) {
         $sortkey = ($conf['sortby'] == 'random') ? 'Random()' : $conf['sortby'];
-        $blog_query = '(blog = '.
-                      $this->sqlitehelper->quote_and_join($conf['blog'],
-                                                          ' OR blog = ').')';
+        
+        $blog_query = '';
+        
+        if (count($conf['blog']) > 0) {
+        
+            $blog_query = '(blog = '.
+                          $this->sqlitehelper->quote_and_join($conf['blog'],
+                                                              ' OR blog = ').')';
+                                                              
+        }                                                             
+                                                              
         $tag_query = $tag_table = "";
         if(count($conf['tags'])){
-            $tag_query  = ' AND (tag = '.
+            
+            if (count($conf['blog']) > 0){
+                
+                $tag_query .= ' AND';
+                
+            }
+            
+            $tag_query  = ' (tag = '.
                           $this->sqlitehelper->quote_and_join($conf['tags'],
                                                               ' OR tag = ').') AND A.pid = B.pid';
             $tag_table  = ', tags B';

--- a/syntax/blog.php
+++ b/syntax/blog.php
@@ -82,7 +82,11 @@ class syntax_plugin_blogtng_blog extends DokuWiki_Syntax_Plugin {
         $conf['tags'] = array_filter(array_map('trim', explode(',', $conf['tags'])));
         $conf['type'] = array_filter(array_map('trim', explode(',', $conf['type'])));
 
-        if(!count($conf['blog'])) $conf['blog'] = array('default');
+        if (($type != 'list') && (!count($conf['blog']))) {
+
+            $conf['blog'] = array('default');
+            
+        }
 
         // higher default limit for tag cloud
         if($type == 'tagcloud' && !$conf['limit']) {


### PR DESCRIPTION
Made 'blog'-configuration optional in <blog list>-syntax. If not given, lists all pages or all pages matching the tags option.

I've tested it on my local dokuwiki stable release.
