### PR TITLE
Escape preview AJAX variables

### DIFF
--- a/script.js
+++ b/script.js
@@ -89,13 +89,13 @@ var blogtng = {
         };
 
         if($('blogtng__comment_name'))
-            ajax.setVar('name',$('blogtng__comment_name').value);
+            ajax.setVar('name',escape($('blogtng__comment_name').value));
         if($('blogtng__comment_mail'))
-            ajax.setVar('mail',$('blogtng__comment_mail').value);
+            ajax.setVar('mail',escape($('blogtng__comment_mail').value));
         if($('blogtng__comment_web'))
-            ajax.setVar('web',$('blogtng__comment_web').value);
+            ajax.setVar('web',escape($('blogtng__comment_web').value));
         if($('wiki__text'))
-            ajax.setVar('text',$('wiki__text').value);
+            ajax.setVar('text',escape($('wiki__text').value));
         ajax.runAJAX();
         return false;
     },


### PR DESCRIPTION
AJAX variables for preview are not escaped. For example, if you put '&call=xyz' in any of the comment fields and click preview, the 'preview' will show

```
AJAX call 'xyz' unknown!
```
