### PR TITLE
break-all for comment admin table

### DIFF
--- a/style.css
+++ b/style.css
@@ -92,6 +92,7 @@ div.dokuwiki div#blogtng__admin table td.comment_name,
 div.dokuwiki div#blogtng__admin table td.comment_web,
 div.dokuwiki div#blogtng__admin table td.entry_created {
     width: 12%;
+    word-break: break-all;
 }
 
 div.dokuwiki div#blogtng__admin table td.comment_text {


### PR DESCRIPTION
Long ipv6 address may break the table in admin interface, add "word-break: break-all;" can fix the problem. 
